### PR TITLE
Add symlink for custom_logging.py in utils directory

### DIFF
--- a/dgdm_histopath/utils/logging.py
+++ b/dgdm_histopath/utils/logging.py
@@ -1,0 +1,1 @@
+custom_logging.py


### PR DESCRIPTION
## Summary
- Adds a symbolic link named `logging.py` in the `dgdm_histopath/utils` directory
- The symlink points to `custom_logging.py` to presumably unify or alias logging utilities

## Changes

### Utilities
- Created a new symlink `logging.py` pointing to `custom_logging.py` in the utils folder

## Test plan
- Verify that importing `dgdm_histopath.utils.logging` correctly references `custom_logging.py`
- Ensure no import errors occur due to the new symlink
- Confirm logging functionality remains consistent with previous behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/51c26a67-0cdb-4dd8-9648-fffa3efb6592

## Summary by Sourcery

Enhancements:
- Introduce logging.py symlink in dgdm_histopath/utils pointing to custom_logging.py for unified logging imports.